### PR TITLE
Expose validation on InjectedFormField

### DIFF
--- a/states_rebuilder_package/lib/src/injected/injected_text_editing/injected_form_field.dart
+++ b/states_rebuilder_package/lib/src/injected/injected_text_editing/injected_form_field.dart
@@ -73,6 +73,9 @@ abstract class InjectedFormField<T> implements InjectedBaseState<T> {
     });
     return _baseFormField.__focusNode as _FocusNode;
   }
+  
+  /// Invoke field validators and return true if the field is valid.
+  bool validate();
 
   /// If true the [TextField] is clickable and selectable but not editable.
   late bool isReadOnly;


### PR DESCRIPTION
There was no validation function on form field.

Example
```dart
final _checkBoxRM= RM.injectFormField<bool>(false, validators: [
  (value) => Validators.isCheckboxValid(
        value,
        'Test',
      ),
]);

//Now possible
_checkBoxRM.validate();
```