### PR TITLE
fix: autoDisposeWhenNotUsed not working

### DIFF
--- a/states_rebuilder_package/lib/scr/state_management/reactive_model/reactive_model_imp.dart
+++ b/states_rebuilder_package/lib/scr/state_management/reactive_model/reactive_model_imp.dart
@@ -365,7 +365,7 @@ class ReactiveModelImp<T> extends ReactiveModel<T> {
 
   @override
   void disposeIfNotUsed() {
-    if (!hasObservers) {
+    if (autoDisposeWhenNotUsed && !hasObservers) {
       dispose();
     }
   }


### PR DESCRIPTION
The Injected is always disposed since the new 6.0 version